### PR TITLE
Fix json decoder exception and catch VideoUnavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## plugin.audio.ytmusic.exp-1.0~beta6
+
+- Fix catch of exception for JsonDecodeError
+- Catch VideoUnavailable exception
+
 ## plugin.audio.ytmusic.exp-1.0~beta5
 
 - Update pytube to version `v23.0.0`

--- a/README.md
+++ b/README.md
@@ -35,19 +35,12 @@ Please follow this guide [https://ytmusicapi.readthedocs.io/en/lat...on-headers]
 
 After you have the cookie and visitor-id strings, just create a text file like the template above and fill the strings.
 
-## Donations:
-
-[Donations for this addon gratefully accepted](https://www.paypal.com/donate/?token=j6CB-F3hQRIqJpcjnFyKuM6J23Xp42bXQFdN-eTbOSOsYIeueWB9JY2hBmSqJ5j_1zl4WThP7G7acw-w&locale.x=BR).
-
-Note: All Donations will be going to Foreverguest.
-
 ## New version:
-
-
-[plugin.audio.ytmusic.exp-1.0~beta5](https://github.com/Goldenfreddy0703/plugin.audio.ytmusic.exp/archive/refs/heads/main.zip)
-- Update ytmusicapi and pytube thanks to @woernsn. 
+[plugin.audio.ytmusic.exp-1.0~beta6](https://github.com/Goldenfreddy0703/plugin.audio.ytmusic.exp/archive/refs/heads/main.zip)
 
 ## Older:
+[plugin.audio.ytmusic.exp-1.0~beta5](hhttps://github.com/Goldenfreddy0703/plugin.audio.ytmusic.exp/archive/4e360a43a2c04815daef7171e360b056a3204965.zip)
+- Update ytmusicapi and pytube thanks to @woernsn. 
 
 [plugin.audio.ytmusic.exp-1.0~beta4](https://app.box.com/s/381gbuuzcu1diletnpjmfnqxnwm6mcw0)
 

--- a/addon.xml
+++ b/addon.xml
@@ -15,9 +15,9 @@
     <summary lang="en">Experimental Youtube [COLOR red]Music[/COLOR] plugin</summary>
     <description lang="en">EXPerimental plugin that lets you play music from Youtube Music.</description>
     <news>
-1.0~beta5 (2022-03-31)
-- Update pytube to version v23.0.0
-- Update ytmusicapi to version 0.21.0
+1.0~beta6 (2022-04-03)
+- Fix catch of exception for JsonDecodeError
+- Catch VideoUnavailable exception
     </news>
     <assets>
       <icon>resources/icon.png</icon>

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.audio.ytmusic.exp"
        name="YT [COLOR red]Music[/COLOR] EXP"
-       version="1.0~beta5"
+       version="1.0~beta6"
        provider-name="ForeverGuest">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>

--- a/resources/lib/login.py
+++ b/resources/lib/login.py
@@ -7,6 +7,7 @@ import xbmcvfs
 import requests
 
 from pytube import YouTube
+from pytube.exceptions import VideoUnavailable
 
 from ytmusicapi2 import MyYtMus
 
@@ -126,11 +127,17 @@ class Login:
         if not 'formats' in streamInfo and 'adaptiveFormats' in streamInfo and 'url' in streamInfo["adaptiveFormats"][0]:
             return streamInfo["adaptiveFormats"][0]['url']
         #return YouTube('http://youtube.com/watch?v='+song_id).streams.get_audio_only().url
-        streams = YouTube('http://youtube.com/watch?v='+song_id).streams
+        
+        streams = []
+        _only_audio = utils.addon.getSettingInt("stream") == 1
+        try:
+            streams = YouTube('http://youtube.com/watch?v='+song_id).streams
+        except VideoUnavailable:
+            _only_audio = True
         for str in streams:
             utils.log(str)
         # return only audio stream?    
-        if(utils.addon.getSettingInt("stream") == 1):
+        if(_only_audio):
             selected = streams.filter(only_audio=True).order_by('bitrate').desc().first()
         else:
             selected = streams.filter(progressive=True).order_by('resolution').desc().first()

--- a/resources/lib/pytube/parser.py
+++ b/resources/lib/pytube/parser.py
@@ -127,7 +127,7 @@ def parse_for_object_from_startpoint(html, start_point):
     full_obj = find_object_from_startpoint(html, start_point)
     try:
         return json.loads(full_obj)
-    except json.decoder.JSONDecodeError:
+    except ValueError:
         try:
             return ast.literal_eval(full_obj)
         except (ValueError, SyntaxError):


### PR DESCRIPTION
There is a problem catching the `JsonDecodeError` within pytube.
I couldn't find the problem as the actual thrown exception is indeed a `JsonDecodeError` but isn't caught.
The more-generic `ValueError` is caught though, so I changed it within the the pytube code - we should think about that once we upgrade pytube again.
Referencing https://github.com/pytube/pytube/issues/1190.

Also, I caught the `VideoUnavailable` exception which was a reason for error messages popping up here and there.

In addition, I removed the `Donation` part of the `README.md` as the link is not existing any longer.