### PR TITLE
Fix dumps in api.py and pytube

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## plugin.audio.ytmusic.exp-1.0~beta14
+
+- Fix syntax error in api.py introduced in 1.0~beta13.
+- Enable pytube JS parser to recognize regular expressions.
+
 ## plugin.audio.ytmusic.exp-1.0~beta13
 
 - Update ytmusicapi to version `0.25.0` to restore library and playlist functionality.

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.audio.ytmusic.exp"
        name="YT [COLOR red]Music[/COLOR] EXP"
-       version="1.0~beta13"
+       version="1.0~beta14"
        provider-name="ForeverGuest">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -15,10 +15,9 @@
     <summary lang="en">Experimental Youtube [COLOR red]Music[/COLOR] plugin</summary>
     <description lang="en">EXPerimental plugin that lets you play music from Youtube Music.</description>
     <news>
-1.0~beta13 (2023-03-16)
-- Update ytmusicapi to version `0.25.0` to restore library and playlist functionality.
-- Refresh playlist after deleting a song from the playlist.
-- Fix error when attempting to display an empty playlist.
+1.0~beta14 (2023-03-19)
+- Fix syntax error in api.py introduced in 1.0~beta13.
+- Enable pytube JS parser to recognize regular expressions.
     </news>
     <assets>
       <icon>resources/icon.png</icon>

--- a/resources/lib/actions.py
+++ b/resources/lib/actions.py
@@ -40,9 +40,7 @@ class Actions:
             self.addToPlaylist(params["videoId"])
         elif action == "del_from_playlist":
             self.api.delFromPlaylist(params["playlist_id"], params["videoId"])
-            import time # timestamp dummy parameter ensures that page is refreshed
-            xbmc.executebuiltin(
-                "ActivateWindow(10502,%s/?path=playlist&playlist_id=%s&timestamp=%s)" % (utils.addon_url, params["playlist_id"], time.time())) # fischcode
+            xbmc.executebuiltin('Container.Refresh')
             self.notify(self.lang(30110))
         elif action == "update_library":
             self.clearCache()

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -130,7 +130,7 @@ class Api:
 
     def addToPlaylist(self, playlist_id, videoId):
         self.getApi().add_playlist_items(playlist_id, videoIds = [videoId])
-        self.load_playlists())
+        self.load_playlists()
 
     def delFromPlaylist(self, playlist_id, videoId):
        entry = storage.delFromPlaylist(playlist_id, videoId)

--- a/resources/lib/pytube/parser.py
+++ b/resources/lib/pytube/parser.py
@@ -74,18 +74,23 @@ def find_object_from_startpoint(html, start_point):
 
     # First letter MUST be a open brace, so we put that in the stack,
     # and skip the first character.
+    last_char = '{'
+    curr_char = None
     stack = [html[0]]
     i = 1
 
     context_closers = {
         '{': '}',
         '[': ']',
-        '"': '"'
+        '"': '"',
+        '/': '/' # javascript regex
     }
 
     while i < len(html):
         if len(stack) == 0:
             break
+        if curr_char not in [' ', '\n']:
+            last_char = curr_char
         curr_char = html[i]
         curr_context = stack[-1]
 
@@ -95,17 +100,19 @@ def find_object_from_startpoint(html, start_point):
             i += 1
             continue
 
-        # Strings require special context handling because they can contain
+        # Strings and regex expressions require special context handling because they can contain
         #  context openers *and* closers
-        if curr_context == '"':
-            # If there's a backslash in a string, we skip a character
+        if curr_context in ['"', '/']:
+            # If there's a backslash in a string or regex expression, we skip a character
             if curr_char == '\\':
                 i += 2
                 continue
         else:
             # Non-string contexts are when we need to look for context openers.
             if curr_char in context_closers.keys():
-                stack.append(curr_char)
+                # Slash starts a regular expression depending on context
+                if not (curr_char == '/' and last_char not in ['(', ',', '=', ':', '[', '!', '&', '|', '?', '{', '}', ';']): 
+                    stack.append(curr_char)
 
         i += 1
 

--- a/resources/lib/pytube/parser.py
+++ b/resources/lib/pytube/parser.py
@@ -134,12 +134,11 @@ def parse_for_object_from_startpoint(html, start_point):
     full_obj = find_object_from_startpoint(html, start_point)
     try:
         return json.loads(full_obj)
-    except Exception as e:
+    except json.decoder.JSONDecodeError:
         try:
             return ast.literal_eval(full_obj)
         except (ValueError, SyntaxError):
             raise HTMLParseError('Could not parse object.')
-
 
 
 def throttling_array_split(js_array):


### PR DESCRIPTION
Eventually, I managed to figure out why pytube suddenly dumped: The function find_object_from_startpoint in pytube parser.py failed to recognize regular expressions and ignore closing characters contained therein, resulting in incomplete code fragments being passed to downstream functions:

- Fix syntax error in api.py introduced in 1.0~beta13.
- Enable pytube parser.py to recognize JS regular expressions.
- Simplify code to refresh song list after deleting from playlist in api.py

Menu structure is still unchanged: I first have to figure out how otaku menus work before attempting to implement a similar mechanism and expand ytmusic.exp menus to expose the full functionality implemented in ytmusicapi.