### PR TITLE
Fix new dump in PyTube cipher.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## plugin.audio.ytmusic.exp-1.0~beta16
+
+- Apply fix to PyTube cipher.py from PyTube Pull Request #1680.
+
 ## plugin.audio.ytmusic.exp-1.0~beta15
 
 - Update to pytube version `15.0.0`

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.audio.ytmusic.exp"
        name="YT [COLOR red]Music[/COLOR] EXP"
-       version="1.0~beta14"
+       version="1.0~beta16"
        provider-name="ForeverGuest">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -16,9 +16,8 @@
     <summary lang="en">Experimental Youtube [COLOR red]Music[/COLOR] plugin</summary>
     <description lang="en">EXPerimental plugin that lets you play music from Youtube Music.</description>
     <news>
-1.0~beta15 (2023-06-10)
-- Update to pytube version 15.0.0
-- Fix a dump in extract.py which apparently only occurs in a kodi environment.
+1.0~beta16 (2023-07-06)
+- Apply fix to PyTube cipher.py from PyTube Pull Request #1680.
     </news>
     <assets>
       <icon>resources/icon.png</icon>

--- a/resources/lib/pytube/cipher.py
+++ b/resources/lib/pytube/cipher.py
@@ -269,7 +269,7 @@ def get_throttling_function_name(js: str) -> str:
         # a.C && (b = a.get("n")) && (b = Bpa[0](b), a.set("n", b),
         # Bpa.length || iha("")) }};
         # In the above case, `iha` is the relevant function name
-        r'a\.[a-zA-Z]\s*&&\s*\([a-z]\s*=\s*a\.get\("n"\)\)\s*&&\s*'
+        r'a\.[a-zA-Z]\s*&&\s*\([a-z]\s*=\s*a\.get\("n"\)\)\s*&&.*?\|\|\s*([a-z]+)', # from https://github.com/pytube/pytube/pull/1680
         r'\([a-z]\s*=\s*([a-zA-Z0-9$]+)(\[\d+\])?\([a-z]\)',
     ]
     logger.debug('Finding throttling function name')


### PR DESCRIPTION
Apply solution to dump in cipher.py (https://github.com/pytube/pytube/issues/1678) from https://github.com/pytube/pytube/pull/1680: In my tests with Kodi Nexus on Windows 11 and libreelec (Raspberry Pi 4), there have been no more errors, I therefore apply this fix even though a small number of pytube users report that the fix does not work in all cases...