### PR TITLE
Update fix for cipher bug and add artist subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## plugin.audio.ytmusic.exp-1.0~~beta17
+
+- Apply another fix to PyTube cipher.py from PyTube Discussions
+- Add 'Artist subscriptions' menu item to YtMusic Library menu
+- Extend navigability of artist search results
+- Add subscribe / unsubscribe context menu to artst menu items
+- Show albumart for album songs in search results
 
 ## plugin.audio.ytmusic.exp-1.0~beta16
 

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.audio.ytmusic.exp"
        name="YT [COLOR red]Music[/COLOR] EXP"
-       version="1.0~beta16"
+       version="1.0~beta17"
        provider-name="ForeverGuest">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -16,8 +16,12 @@
     <summary lang="en">Experimental Youtube [COLOR red]Music[/COLOR] plugin</summary>
     <description lang="en">EXPerimental plugin that lets you play music from Youtube Music.</description>
     <news>
-1.0~beta16 (2023-07-06)
-- Apply fix to PyTube cipher.py from PyTube Pull Request #1680.
+1.0~beta17 (2023-08-26)
+- Apply another fix to PyTube cipher.py from PyTube discussions
+- Add 'Artist subscriptions' menu item to YtMusic Library menu
+- Extend navigability of artist search results
+- Add subscribe / unsubscribe context menu to artst menu items
+- Show albumart for album songs in search results
     </news>
     <assets>
       <icon>resources/icon.png</icon>

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -246,6 +246,14 @@ msgctxt "#30225"
 msgid "Recents"
 msgstr ""
 
+msgctxt "#30226"
+msgid "Artist subscriptions"
+msgstr ""
+
+msgctxt "#30227"
+msgid "Singles"
+msgstr ""
+
 ####
 # Context actions
 ####
@@ -335,6 +343,14 @@ msgstr ""
 
 msgctxt "#30322"
 msgid "Play all from here"
+msgstr ""
+
+msgctxt "#30323"
+msgid "Subscribe artist"
+msgstr ""
+
+msgctxt "#30324"
+msgid "Unsubscribe artist"
 msgstr ""
 
 ####

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -218,6 +218,14 @@ msgctxt "#30222"
 msgid "Browse stations"
 msgstr "Sender durchsuchen"
 
+msgctxt "#30223"
+msgid "New search"
+msgstr "Neue Suche"
+
+msgctxt "#30226"
+msgid "Artist subscriptions"
+msgstr "Abonnierte Künstler"
+
 ####
 # Context actions
 ####
@@ -283,11 +291,11 @@ msgstr ""
 
 msgctxt "#30316"
 msgid "Create playlist"
-msgstr ""
+msgstr "Playlist erstellen"
 
 msgctxt "#30317"
 msgid "Delete playlist"
-msgstr ""
+msgstr "Playlist löschen"
 
 msgctxt "#30318"
 msgid "Delete station"
@@ -304,6 +312,14 @@ msgstr ""
 msgctxt "#30321"
 msgid "Play in Youtube - shuffle"
 msgstr "Alle zufällig in YouTube wiedergeben"
+
+msgctxt "#30323"
+msgid "Subscribe artist"
+msgstr "Künstler abonnieren"
+
+msgctxt "#30324"
+msgid "Unsubscribe artist"
+msgstr "Abonnement beenden"
 
 ####
 # Messages

--- a/resources/lib/actions.py
+++ b/resources/lib/actions.py
@@ -61,6 +61,12 @@ class Actions:
                 self.api.deletePlaylist(params["playlist_id"])
                 xbmc.executebuiltin("ActivateWindow(10502,%s/?path=library)" % utils.addon_url)
                 self.notify(self.lang(30110))
+        elif action == "subscribe_artist":
+            self.api.getApi().subscribe_artists(params["artist_id"])
+            self.notify(self.lang(30110))
+        elif action == "unsubscribe_artist":
+            self.api.getApi().unsubscribe_artists(params["artist_id"])
+            xbmc.executebuiltin('Container.Refresh')
         elif action == "artist_topsongs":
             artist_id = self.api.getApi().get_track_info(params["videoId"])['artistId'][0]
             xbmc.executebuiltin("ActivateWindow(10502,%s/?path=artist_topsongs&artistid=%s)" % (utils.addon_url, artist_id))

--- a/resources/lib/pytube/cipher.py
+++ b/resources/lib/pytube/cipher.py
@@ -269,7 +269,7 @@ def get_throttling_function_name(js: str) -> str:
         # a.C && (b = a.get("n")) && (b = Bpa[0](b), a.set("n", b),
         # Bpa.length || iha("")) }};
         # In the above case, `iha` is the relevant function name
-        r'a\.[a-zA-Z]\s*&&\s*\([a-z]\s*=\s*a\.get\("n"\)\)\s*&&.*?\|\|\s*([a-z]+)', # from https://github.com/pytube/pytube/pull/1680
+        r'a\.[a-zA-Z]\s*&&\s*\([a-z]\s*=\s*a\.get\("n"\)\)\s*&&\s*.*\|\|\s*(.*)\(',
         r'\([a-z]\s*=\s*([a-zA-Z0-9$]+)(\[\d+\])?\([a-z]\)',
     ]
     logger.debug('Finding throttling function name')


### PR DESCRIPTION
Hi Goldenfreddy
In addition to updating the fix to PyTube cipher.py with another version from PyTube discussions, I've made a first attempt to add features to ytmusic.exp while keeping the structure of the code unchanged:

- Add 'Artist subscriptions' menu item to YtMusic Library menu
- Extend navigability of artist search results
- Add subscribe / unsubscribe context menu to artst menu items
- Show albumart for album songs in search results

I agree with you that a substantial re-work would be necessary before it makes sense to include even more of the many features of ytmusicapi: I hope I will eventually find time for such a task, but first need to identify a good framework for the dynamic handling of menus and actions. Otaku that you mentioned does a nice job with its menus, but the code for handling the menus and actions is integrated with everything else and therefore not easily separable...

Best regards,
Bernt